### PR TITLE
fix results for quadratic voting example with 3 users, 4 options, 9 c…

### DIFF
--- a/docs/architecture/data-schemes/process.md
+++ b/docs/architecture/data-schemes/process.md
@@ -173,7 +173,7 @@ Given diferent process with various parameters, below is an example of the resul
 <td class="cell-seven">true</td></tr>
 <tr><td class="cell-title">Quadratic voting: 4 options, 9 credits to spend</td>
 	<td class="cell-one">[2,2,1,0] [1,1,1,1] [0,3,0,0]</td>
-<td class="cell-two">[ [1,1,1,0], [0,1,1,1], [1,2,0,0], [2,1,0,0] ]</td>
+<td class="cell-two">[ [2,1,0], [2,1,3], [1,1,0], [0,1,0] ]</td>
 <td class="cell-three">4</td>
 <td class="cell-four">-</td>
 <td class="cell-five">9</td>


### PR DESCRIPTION
Actual documentation on [process](https://docs.vocdoni.io/#/architecture/data-schemes/process) page about quadratic voting :

```
// vote examples
[2,2,1,0]
[1,1,1,1]
[0,3,0,0]

// results
[ [1,1,1,0], [0,1,1,1], [1,2,0,0], [2,1,0,0] ]
```

I don't understand these results.
Results array should have size 4, but each subarray should have size 3 (number of users voting)

What I would expect as a result :

```
// results
[ [2,1,0], [2,1,3], [1,1,0], [0,1,0] ]
```

Do I miss something ?
