### PR TITLE
Fixed `encryptedVotes` in envelope type documentation

### DIFF
--- a/src/architecture/smart-contracts/process.md
+++ b/src/architecture/smart-contracts/process.md
@@ -198,7 +198,7 @@ The envelope type tells how the vote envelope is formatted and handled. Its valu
      |||||
      ||||`- serial
      |||`-- anonymous
-     ||`--- encryptedVote
+     ||`--- encryptedVotes
      |`---- uniqueValues
       `---- costFromWeight 
 ```


### PR DESCRIPTION
Changed from `encryptedVote` to `encryptedVotes` in the envelope type specs from the process